### PR TITLE
Implementing hiding and showing role lists on menu item edit pages.

### DIFF
--- a/menu_per_role.module
+++ b/menu_per_role.module
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\menu_per_role\Form\MenuPerRoleAdminSettings;
 
 /**
  * Implements hook_entity_base_field_info_alter().
@@ -55,12 +56,39 @@ function menu_per_role_form_menu_link_content_form_alter(&$form, FormStateInterf
   $uid1_see_all = $config->get('uid1_see_all', FALSE);
   $admin_see_all = $config->get('admin_see_all', FALSE);
   $hide_show_mode = (int) $config->get('hide_show', MenuPerRoleAdminSettings::MODE_DISPLAY_BOTH);
+  $hide_on_content_mode = (int) $config->get('hide_on_content', MenuPerRoleAdminSettings::MODE_DISPLAY_ON_CONTENT_ALWAYS);
 
   $user = \Drupal::currentUser();
 
+  $is_uid_1 = $uid1_see_all && ((int) $user->id() == 1);
+  $is_admin = $admin_see_all && $user->hasPermission("administer menu_per_role");
+  $alwaysShow = $is_uid_1 || $is_admin;
+
+  // Check if content mode setting applies, and if fields should be hidden.
+  $is_content = FALSE;
+  if ($hide_on_content_mode != MenuPerRoleAdminSettings::MODE_DISPLAY_ON_CONTENT_ALWAYS) {
+    $form_obj = $form_state->getFormObject();
+    $menu_link = $form_obj->getEntity();
+    if ($menu_link) {
+      $link_url = $menu_link->getUrlObject();
+      if ($link_url->isRouted()) {
+        $route_params = $link_url->getRouteParameters();
+        if (array_key_exists("node", $route_params)) {
+          // Nodes routes will contain a 'node' with 'nid' value.
+          if ($hide_on_content_mode == MenuPerRoleAdminSettings::MODE_DISPLAY_ON_CONTENT_NO_NODE_ACCESS) {
+            // For the existance of any hook_node_grants() implementations.
+            $is_content = !empty(\Drupal::moduleHandler()->getImplementations('node_grants'));
+          }
+          // If false, then check if the setting is display never.
+          $is_content = $is_content || $hide_on_content_mode == MenuPerRoleAdminSettings::MODE_DISPLAY_ON_CONTENT_NEVER;
+        }
+      }
+    }
+  }
+
   // Check for the display of each field.
-  $display_show_roles = $alwaysShow || $hide_show_mode != MenuPerRoleAdminSettings::MODE_DISPLAY_ONLY_HIDE;
-  $display_hide_roles = $alwaysShow || $hide_show_mode != MenuPerRoleAdminSettings::MODE_DISPLAY_ONLY_SHOW;
+  $display_show_roles = $alwaysShow || (!$is_content && $hide_show_mode != MenuPerRoleAdminSettings::MODE_DISPLAY_ONLY_HIDE);
+  $display_hide_roles = $alwaysShow || (!$is_content && $hide_show_mode != MenuPerRoleAdminSettings::MODE_DISPLAY_ONLY_SHOW);
 
   // Hide fields if they need to be.
   if (!$display_show_roles) {

--- a/menu_per_role.module
+++ b/menu_per_role.module
@@ -69,7 +69,7 @@ function menu_per_role_form_menu_link_content_form_alter(&$form, FormStateInterf
   if ($hide_on_content_mode != MenuPerRoleAdminSettings::MODE_DISPLAY_ON_CONTENT_ALWAYS) {
     $form_obj = $form_state->getFormObject();
     $menu_link = $form_obj->getEntity();
-    if ($menu_link) {
+    if ($menu_link && !$menu_link->isNew()) {
       $link_url = $menu_link->getUrlObject();
       if ($link_url->isRouted()) {
         $route_params = $link_url->getRouteParameters();

--- a/menu_per_role.module
+++ b/menu_per_role.module
@@ -8,9 +8,12 @@
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_entity_base_field_info_alter().
+ *
+ * Addes two fields to menu_link_content, so access restrictions can be set.
  */
 function menu_per_role_entity_base_field_info_alter(&$fields, EntityTypeInterface $entity_type) {
   if ($entity_type->id() != 'menu_link_content') {
@@ -31,11 +34,39 @@ function menu_per_role_entity_base_field_info_alter(&$fields, EntityTypeInterfac
   $fields['menu_per_role__hide_role'] = BaseFieldDefinition::create('entity_reference')
     ->setName('menu_per_role__hide_role')
     ->setTargetEntityTypeId('menu_link_content')
-    ->setLabel(t('Roles able to not see the menu link'))
+    ->setLabel(t('Roles not able see the menu link.'))
     ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
     ->setSetting('target_type', 'user_role')
     ->setDisplayOptions('form', [
       'type' => 'options_buttons',
       'weight' => 0,
     ]);
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Alter menu_link_content fields to hide extra fields on content.
+ */
+function menu_per_role_form_menu_link_content_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $config = \Drupal::config('menu_per_role.settings');
+
+  // Get config properties.
+  $uid1_see_all = $config->get('uid1_see_all', FALSE);
+  $admin_see_all = $config->get('admin_see_all', FALSE);
+  $hide_show_mode = (int) $config->get('hide_show', MenuPerRoleAdminSettings::MODE_DISPLAY_BOTH);
+
+  $user = \Drupal::currentUser();
+
+  // Check for the display of each field.
+  $display_show_roles = $alwaysShow || $hide_show_mode != MenuPerRoleAdminSettings::MODE_DISPLAY_ONLY_HIDE;
+  $display_hide_roles = $alwaysShow || $hide_show_mode != MenuPerRoleAdminSettings::MODE_DISPLAY_ONLY_SHOW;
+
+  // Hide fields if they need to be.
+  if (!$display_show_roles) {
+    $form["menu_per_role__show_role"]["#access"] = FALSE;
+  }
+  if (!$display_hide_roles) {
+    $form["menu_per_role__hide_role"]["#access"] = FALSE;
+  }
 }

--- a/menu_per_role.routing.yml
+++ b/menu_per_role.routing.yml
@@ -1,7 +1,7 @@
 menu_per_role.settings:
   path: 'admin/config/system/menu_per_role'
   defaults:
-    _form: Drupal\menu_per_role\Form\MenuPermRoleAdminSettings
+    _form: Drupal\menu_per_role\Form\MenuPerRoleAdminSettings
     _title: 'Menu per Role'
   requirements:
     _permission: 'administer menu_per_role'

--- a/src/Form/MenuPerRoleAdminSettings.php
+++ b/src/Form/MenuPerRoleAdminSettings.php
@@ -14,6 +14,21 @@ use Drupal\Core\Url;
 class MenuPerRoleAdminSettings extends ConfigFormBase {
 
   /**
+   * Display both hide and show role checkbox lists.
+   */
+  const MODE_DISPLAY_BOTH = 0;
+
+  /**
+   * Display only the hide from checkbox list.
+   */
+  const MODE_DISPLAY_ONLY_HIDE = 1;
+
+  /**
+   * Display only the show to checkbox list.
+   */
+  const MODE_DISPLAY_ONLY_SHOW = 2;
+
+  /**
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
@@ -58,9 +73,9 @@ class MenuPerRoleAdminSettings extends ConfigFormBase {
       '#type' => 'radios',
       '#title' => $this->t('Select what is shown when editing menu items'),
       '#options' => [
-        0 => $this->t('Hide and Show check boxes'),
-        1 => $this->t('Only Hide check boxes'),
-        2 => $this->t('Only Show check boxes')
+        static::MODE_DISPLAY_BOTH => $this->t('Hide and Show check boxes'),
+        static::MODE_DISPLAY_ONLY_HIDE => $this->t('Only Hide check boxes'),
+        static::MODE_DISPLAY_ONLY_SHOW => $this->t('Only Show check boxes'),
       ],
       '#description' => $this->t('By default, both list of check boxes are shown when editing a menu item (in the menu administration area or while editing a node.) This option let you choose to only show the "Show menu item only to selected roles" or "Hide menu item from selected roles". WARNING: changing this option does not change the existing selection. This means some selection will become invisible when you hide one of the set of check boxes...'),
       '#default_value' => $config->get('hide_show'),

--- a/src/Form/MenuPerRoleAdminSettings.php
+++ b/src/Form/MenuPerRoleAdminSettings.php
@@ -29,6 +29,21 @@ class MenuPerRoleAdminSettings extends ConfigFormBase {
   const MODE_DISPLAY_ONLY_SHOW = 2;
 
   /**
+   * Always display fields on links to content.
+   */
+  const MODE_DISPLAY_ON_CONTENT_ALWAYS = 0;
+
+  /**
+   * Only display fields on menu items if there are no node_access providers.
+   */
+  const MODE_DISPLAY_ON_CONTENT_NO_NODE_ACCESS = 1;
+
+  /**
+   * Never display fields on links to content.
+   */
+  const MODE_DISPLAY_ON_CONTENT_NEVER = 2;
+
+  /**
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
@@ -81,6 +96,18 @@ class MenuPerRoleAdminSettings extends ConfigFormBase {
       '#default_value' => $config->get('hide_show'),
     ];
 
+    $form['hide_on_content'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Show fileds on menu items that point to content'),
+      '#options' => [
+        static::MODE_DISPLAY_ON_CONTENT_ALWAYS => $this->t('Always'),
+        static::MODE_DISPLAY_ON_CONTENT_NO_NODE_ACCESS => $this->t('If NO Node Access Modules are enabled.'),
+        static::MODE_DISPLAY_ON_CONTENT_NEVER => $this->t('Never'),
+      ],
+      '#description' => $this->t('Fields are shown when editing any menu item. This will hide the fields when editing menu items, that point to nodes. This is useful on sites using Node Access modules.'),
+      '#default_value' => $config->get('hide_on_content'),
+    ];
+
     return $form;
   }
 
@@ -92,6 +119,7 @@ class MenuPerRoleAdminSettings extends ConfigFormBase {
       ->set('uid1_see_all', $form_state->getValue('uid1_see_all'))
       ->set('admin_see_all', $form_state->getValue('admin_see_all'))
       ->set('hide_show', $form_state->getValue('hide_show'))
+      ->set('hide_on_content', $form_state->getValue('hide_on_content'))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/src/Form/MenuPerRoleAdminSettings.php
+++ b/src/Form/MenuPerRoleAdminSettings.php
@@ -11,7 +11,7 @@ use Drupal\Core\Url;
  *
  * @package Drupal\menu_per_role\Form
  */
-class MenuPermRoleAdminSettings extends ConfigFormBase {
+class MenuPerRoleAdminSettings extends ConfigFormBase {
 
   /**
    * {@inheritdoc}

--- a/src/MenuPerRoleLinkTreeManipulator.php
+++ b/src/MenuPerRoleLinkTreeManipulator.php
@@ -51,13 +51,13 @@ class MenuPerRoleLinkTreeManipulator extends DefaultMenuLinkTreeManipulators {
         // Check whether this role has visibility access (must be present).
         if ($show_role && count(array_intersect($show_role, $this->account->getRoles())) == 0) {
           $result = $result->andIf(AccessResult::forbidden()
-            ->addCacheContexts(array('user.roles')));
+            ->addCacheContexts(['user.roles']));
         }
 
         // Check whether this role has visibility access (must not be present).
         if ($hidden_role && count(array_intersect($hidden_role, $this->account->getRoles())) > 0) {
           $result = $result->andIf(AccessResult::forbidden()
-            ->addCacheContexts(array('user.roles')));
+            ->addCacheContexts(['user.roles']));
         }
       }
 


### PR DESCRIPTION
I noticed that the settings and the admin page that controlled the display of the fields on the menu item edit page, did not work, and there was not code to implement them.

Additionally i added a setting to allow for hiding of the fields on the page for menu items that go to content entities. Since on sites using modules that implement node access control, you don't always want the ability to hide menu items based on the role listings, since some content maintainers may not be aware that those options don't actually restrict access to the nodes, just the display of them menu items.